### PR TITLE
return only parsed keys/values

### DIFF
--- a/lib/envc.js
+++ b/lib/envc.js
@@ -6,6 +6,7 @@
 
 var Parser = require('./parser');
 var Loader = require('./loader');
+var extend = require('params').extend;
 
 /**
  * Load given `.env` file and set the variables
@@ -20,15 +21,13 @@ module.exports = function(options) {
   var parser = null;
   var loader = new Loader(options);
   var files = loader.load();
+  var parsed = {};
 
   files.forEach(function(file) {
     var parser = new Parser(options);
-    var vars = parser.parse(file);
-
-    Object.keys(vars).forEach(function(key) {
-      process.env[key] = vars[key];
-    });
+    extend(parsed, parser.parse(file));
   });
 
-  return process.env;
+  extend(process.env, parsed);
+  return parsed;
 };

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "devDependencies": {
     "mini": "^1.1.0"
+  },
+  "dependencies": {
+    "params": "^0.1.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,18 +2,23 @@ var assert = require('assert');
 var envc = require('../');
 
 test('default location', function() {
-  var env = envc();
-  assert(env.ENVC);
+  envc();
+  assert(process.env.ENVC);
+});
+
+test('updated keys', function() {
+  var keys = Object.keys(envc());
+  assert.deepEqual(keys, ['ENVC']);
 });
 
 test('custom location', function() {
-  var env = envc({ path: 'test/fixtures', name: 'envc-one' });
-  assert(env.ENVC_ONE);
+  envc({ path: 'test/fixtures', name: 'envc-one' });
+  assert(process.env.ENVC_ONE);
 });
 
 test('prefer files with .env.{NODE_ENV} over .env', function() {
-  var env = envc({ path: 'test/fixtures', name: 'ignored' });
-  assert.equal(env.ENVC_SOURCE, 'test');
+  envc({ path: 'test/fixtures', name: 'ignored' });
+  assert.equal(process.env.ENVC_SOURCE, 'test');
 });
 
 test('do not throw when the file cannot be found', function() {
@@ -23,7 +28,7 @@ test('do not throw when the file cannot be found', function() {
 });
 
 test('inheritance', function() {
-  var env = envc({ path: 'test/fixtures', name: 'inheritance' });
-  assert.equal(env.A, 1);
-  assert.equal(env.B, 3);
+  envc({ path: 'test/fixtures', name: 'inheritance' });
+  assert.equal(process.env.A, 1);
+  assert.equal(process.env.B, 3);
 });


### PR DESCRIPTION
This PR is to return the parsed keys/values as those can be useful for meta programs that need the list of configured keys.

Fortunately, if the caller wants to continue with the old behavior, they simply reference `process.env`.

Not sure I love the use of `_extend`; however, I doubt the API will change.
