### PR TITLE
Support .env.local overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ envc will try to load:
 
 - {name}
 - {name}.{NODE_ENV}
+- {name}.local
 
 ### Interpolation
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -47,6 +47,7 @@ Loader.prototype.load = function() {
   var files = [
     path.resolve(path.join(this._path, this._name)),
     path.resolve(path.join(this._path, this._name + '.' + this._nodeenv)),
+    path.resolve(path.join(this._path, this._name + '.local')),
   ];
 
   files.forEach(function(file) {

--- a/test/fixtures/local.local
+++ b/test/fixtures/local.local
@@ -1,0 +1,1 @@
+ENVC_SOURCE=local

--- a/test/fixtures/local.test
+++ b/test/fixtures/local.test
@@ -1,0 +1,1 @@
+ENVC_SOURCE=wrong

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,6 +21,11 @@ test('prefer files with .env.{NODE_ENV} over .env', function() {
   assert.equal(process.env.ENVC_SOURCE, 'test');
 });
 
+test('prefer files with .env.local over .env.{NODE_ENV}', function() {
+  envc({ path: 'test/fixtures', name: 'local' });
+  assert.equal(process.env.ENVC_SOURCE, 'local');
+});
+
 test('do not throw when the file cannot be found', function() {
   assert.doesNotThrow(function() {
     envc({ path: 'invalid/path' });


### PR DESCRIPTION
## Scope

dotenv supports local overrides 

This allows sharing env variables w/o constantly copying .env-example 

The idea is: 

- you check-in your full `.env.development` file for the team to share 
- and only change local overrides in `.env.local`
